### PR TITLE
Fixed XP gain timer logic in event handler

### DIFF
--- a/modules/xprep.lua
+++ b/modules/xprep.lua
@@ -583,7 +583,9 @@ DFRL:RegisterModule("xprep", 1, function()
                 f:SetScript("OnUpdate", function()
                     Setup.xpOnGainTimer = Setup.xpOnGainTimer - arg1
                     if Setup.xpOnGainTimer <= 0 then
-                        Setup.xpBarText:Hide()
+                        if not DFRL:GetConfig("xprep", "showXpText") or DFRL:GetConfig("xprep", "hoverXP") then
+                            Setup.xpBarText:Hide()
+                        end
                         this:SetScript("OnUpdate", nil)
                     end
                 end)


### PR DESCRIPTION
When the "Show XP text on the XP bar" setting is enabled, the XP text unexpectedly disappears after gaining experience, even though it should remain permanently visible.

Modified the timer expiration logic to check user settings before hiding the text. The text will now only be hidden if:
- The "Show XP text" setting is disabled, OR
- The "Show XP text on hover" setting is enabled (hover behavior takes precedence)