### PR TITLE
Workaround for display issues for target status bar text 

### DIFF
--- a/modules/targetframe.lua
+++ b/modules/targetframe.lua
@@ -436,7 +436,26 @@ DFRL:RegisterModule("targetframe", 1, function()
     f:RegisterEvent("UNIT_RAGE")
     f:RegisterEvent("UNIT_FOCUS")
     f:SetScript("OnEvent", function()
-        if event == "PLAYER_TARGET_CHANGED" or event == "PLAYER_ENTERING_WORLD" then
+        if event == "PLAYER_ENTERING_WORLD" then
+            local currentValue = GetCVar("statusBarText")
+            if currentValue ~= "0" then
+                SetCVar("statusBarText", "0")
+                StaticPopupDialogs["DFRL_RELOAD_REQUIRED"] = {
+                    text = "DragonflightReloaded has disabled the 'Show Status Text' setting to prevent display issues. A UI reload is required to complete this change.",
+                    button1 = "Reload Now",
+                    button2 = "Later",
+                    OnAccept = function()
+                        ChatFrameEditBox:SetText("/reload")
+                        ChatEdit_SendText(ChatFrameEditBox)
+                    end,
+                    timeout = 0,
+                    whileDead = 1,
+                    hideOnEscape = 1
+                }
+                StaticPopup_Show("DFRL_RELOAD_REQUIRED")
+                return
+            end
+        elseif event == "PLAYER_TARGET_CHANGED" then
             Setup:CheckTargetTapped()
             Setup:UpdateTexts()
             Setup:UpdateBarColor()

--- a/modules/targetframe.lua
+++ b/modules/targetframe.lua
@@ -440,20 +440,7 @@ DFRL:RegisterModule("targetframe", 1, function()
             local currentValue = GetCVar("statusBarText")
             if currentValue ~= "0" then
                 SetCVar("statusBarText", "0")
-                StaticPopupDialogs["DFRL_RELOAD_REQUIRED"] = {
-                    text = "DragonflightReloaded has disabled the 'Show Status Text' setting to prevent display issues. A UI reload is required to complete this change.",
-                    button1 = "Reload Now",
-                    button2 = "Later",
-                    OnAccept = function()
-                        ChatFrameEditBox:SetText("/reload")
-                        ChatEdit_SendText(ChatFrameEditBox)
-                    end,
-                    timeout = 0,
-                    whileDead = 1,
-                    hideOnEscape = 1
-                }
-                StaticPopup_Show("DFRL_RELOAD_REQUIRED")
-                return
+                ReloadUI()
             end
         elseif event == "PLAYER_TARGET_CHANGED" then
             Setup:CheckTargetTapped()


### PR DESCRIPTION
I tried to see if I was able to detect why we get an issue as described in https://github.com/MtxGrower33/DragonflightReloaded/issues/8 but I couldn't identify the root cause. As a workaround I propose this.

Added automatic detection and disabling of the statusBarText CVar on login:
Detection: Check the current value of statusBarText when PLAYER_ENTERING_WORLD event fires

Automatic disable: Set statusBarText to "0" if it's currently enabled

User notification: Show a popup dialog explaining the change and offering to reload the UI

One-time action: Only triggers when the setting actually needs to be changed and only checked on login