### PR TITLE
Fix modules shows as always enabled in gui

### DIFF
--- a/modules/gui/gui.lua
+++ b/modules/gui/gui.lua
@@ -1035,7 +1035,7 @@ DFRL:RegisterModule("gui", 2, function()
 
                 -- set initial state
                 local isEnabled = true
-                if tempDB and tempDB[checkbox.moduleName] and tempDB[checkbox.moduleName]["enabled"] then
+                if tempDB and tempDB[checkbox.moduleName] and tempDB[checkbox.moduleName]["enabled"] ~= nil then
                     isEnabled = tempDB[checkbox.moduleName]["enabled"]
                 end
                 checkbox:SetChecked(isEnabled)


### PR DESCRIPTION
Condition when checking was always false, thus making modules in gui to always appear as enabled even when they are disabled.